### PR TITLE
Wire auto-refresh toggle to re-fetch historical data on resume

### DIFF
--- a/app/src/main/java/com/gasleakdetector/ui/main/HomeFragment.java
+++ b/app/src/main/java/com/gasleakdetector/ui/main/HomeFragment.java
@@ -6,7 +6,7 @@
  * Author  : Phuc An <pan2512811@gmail.com>
  * Email   : pan2512811@gmail.com
  * GitHub  : https://github.com/gasleakdetector/gasleakdetector
- * Modified: 2026-05-29
+ * Modified: 2026-01-08
  */
 package com.gasleakdetector.ui.main;
 
@@ -160,6 +160,16 @@ public class HomeFragment extends Fragment
         gasLevelText  = null;
         gasStatusText = null;
         nodeInfoText  = null;
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (!isSafe()) return;
+        if (sharedPrefs.getAutoRefreshEnabled() && sharedPrefs.hasRealtimeConfig()) {
+            app.setHistoricalDataLoaded(false);
+            loadHistoricalData();
+        }
     }
 
     /* ------------------------------------------------------------------ */


### PR DESCRIPTION
Closes #66

- The auto-refresh setting in `SharedPrefs` was never consumed anywhere. The toggle in Settings let users enable it but nothing happened.

- This change wires it to a historical data re-fetch when `HomeFragment` resumes, so the chart updates with fresh data from the server.