### PR TITLE
Extract duplicated ISO 8601 normalization into DateUtils

### DIFF
--- a/app/src/main/java/com/gasleakdetector/data/model/HistoricalDataPoint.java
+++ b/app/src/main/java/com/gasleakdetector/data/model/HistoricalDataPoint.java
@@ -6,11 +6,12 @@
  * Author  : Phuc An <pan2512811@gmail.com>
  * Email   : pan2512811@gmail.com
  * GitHub  : https://github.com/gasleakdetector/gasleakdetector
- * Modified: 2026-05-26
+ * Modified: 2026-01-08
  */
 package com.gasleakdetector.data.model;
 
 import android.util.Log;
+import com.gasleakdetector.util.DateUtils;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -106,29 +107,13 @@ public class HistoricalDataPoint {
         String raw = bucket != null ? bucket : createdAt;
         if (raw == null || raw.isEmpty()) return System.currentTimeMillis();
 
-        // ISO 8601 with a colon in the offset (e.g. +07:00) isn't supported by SimpleDateFormat;
-        // strip the colon to get +0700.
-        String normalized = raw;
-        try {
-            if (normalized.length() > 6) {
-                String tail = normalized.substring(normalized.length() - 6);
-                if (tail.matches("[+-]\\d{2}:\\d{2}")) {
-                    normalized = normalized.substring(0, normalized.length() - 6) + tail.replace(":", "");
-                }
-            }
-            if (normalized.endsWith("Z")) {
-                normalized = normalized.substring(0, normalized.length() - 1) + "+0000";
-            }
-        } catch (Exception ignored) {}
-
-        // Supabase returns microseconds (6 digits after dot). SimpleDateFormat only handles
-        // milliseconds (3 digits). Truncate fractional seconds to 3 digits before parsing.
-        String truncated = normalized.replaceAll("(\\.\\d{3})\\d+", "$1");
+        String normalized = DateUtils.normalizeIso8601(raw);
+        if (normalized == null) return System.currentTimeMillis();
 
         Date d;
-        d = tryParse(truncated, "yyyy-MM-dd'T'HH:mm:ss.SSSZ"); if (d != null) return d.getTime();
-        d = tryParse(truncated, "yyyy-MM-dd'T'HH:mm:ssZ");      if (d != null) return d.getTime();
-        d = tryParse(raw,       "yyyy-MM-dd");                   if (d != null) return d.getTime();
+        d = tryParse(normalized, "yyyy-MM-dd'T'HH:mm:ss.SSSZ"); if (d != null) return d.getTime();
+        d = tryParse(normalized, "yyyy-MM-dd'T'HH:mm:ssZ");      if (d != null) return d.getTime();
+        d = tryParse(raw,        "yyyy-MM-dd");                   if (d != null) return d.getTime();
 
         Log.w(TAG, "Cannot parse timestamp: " + raw);
         return System.currentTimeMillis();

--- a/app/src/main/java/com/gasleakdetector/ui/main/StatisticsFragment.java
+++ b/app/src/main/java/com/gasleakdetector/ui/main/StatisticsFragment.java
@@ -6,7 +6,7 @@
  * Author  : Phuc An <pan2512811@gmail.com>
  * Email   : pan2512811@gmail.com
  * GitHub  : https://github.com/gasleakdetector/gasleakdetector
- * Modified: 2026-06-15
+ * Modified: 2026-01-08
  */
 package com.gasleakdetector.ui.main;
 
@@ -32,6 +32,7 @@ import com.gasleakdetector.data.model.HourlyStatPoint;
 import com.gasleakdetector.data.model.RealtimeConfig;
 import com.gasleakdetector.data.prefs.SharedPrefs;
 import com.gasleakdetector.ui.widget.StatsChartView;
+import com.gasleakdetector.util.DateUtils;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -233,13 +234,8 @@ public class StatisticsFragment extends Fragment {
     private String formatBucket(String bucket, SimpleDateFormat sdf) {
         if (bucket == null || bucket.isEmpty()) return "--";
         try {
-            String norm = bucket;
-            if (norm.endsWith("Z")) norm = norm.substring(0, norm.length() - 1) + "+0000";
-            if (norm.length() > 6) {
-                String tail = norm.substring(norm.length() - 6);
-                if (tail.matches("[+-]\\d{2}:\\d{2}"))
-                    norm = norm.substring(0, norm.length() - 6) + tail.replace(":", "");
-            }
+            String norm = DateUtils.normalizeIso8601(bucket);
+            if (norm == null) return bucket;
             SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
             parser.setTimeZone(TimeZone.getTimeZone("UTC"));
             Date d = parser.parse(norm);

--- a/app/src/main/java/com/gasleakdetector/ui/widget/StatsChartView.java
+++ b/app/src/main/java/com/gasleakdetector/ui/widget/StatsChartView.java
@@ -6,7 +6,7 @@
  * Author  : Phuc An <pan2512811@gmail.com>
  * Email   : pan2512811@gmail.com
  * GitHub  : https://github.com/gasleakdetector/gasleakdetector
- * Modified: 2026-06-15
+ * Modified: 2026-01-08
  */
 package com.gasleakdetector.ui.widget;
 
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 import androidx.core.content.ContextCompat;
 import com.gasleakdetector.R;
+import com.gasleakdetector.util.DateUtils;
 
 public class StatsChartView extends View {
 
@@ -153,13 +154,8 @@ public class StatsChartView extends View {
     private String parseBucketLabel(String bucket, SimpleDateFormat sdf) {
         if (bucket == null || bucket.isEmpty()) return "--";
         try {
-            String norm = bucket;
-            if (norm.endsWith("Z")) norm = norm.substring(0, norm.length() - 1) + "+0000";
-            if (norm.length() > 6) {
-                String tail = norm.substring(norm.length() - 6);
-                if (tail.matches("[+-]\\d{2}:\\d{2}"))
-                    norm = norm.substring(0, norm.length() - 6) + tail.replace(":", "");
-            }
+            String norm = DateUtils.normalizeIso8601(bucket);
+            if (norm == null) return bucket.substring(11, Math.min(16, bucket.length()));
             SimpleDateFormat p = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
             p.setTimeZone(TimeZone.getTimeZone("UTC"));
             Date d = p.parse(norm);

--- a/app/src/main/java/com/gasleakdetector/util/DateUtils.java
+++ b/app/src/main/java/com/gasleakdetector/util/DateUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Phuc An
+ * Licensed under the Apache License, Version 2.0
+ *
+ * Project : Gas Leak Detector
+ * Author  : Phuc An <pan2512811@gmail.com>
+ * Email   : pan2512811@gmail.com
+ * GitHub  : https://github.com/gasleakdetector/gasleakdetector
+ * Modified: 2026-01-08
+ */
+package com.gasleakdetector.util;
+
+/**
+ * Shared ISO 8601 date/time normalization utilities.
+ *
+ * SimpleDateFormat cannot parse:
+ * - Colon in the timezone offset (+07:00 → +0700)
+ * - Trailing Z suffix (Z → +0000)
+ * - Microsecond fractional seconds (truncated to 3 digits)
+ */
+public class DateUtils {
+
+    /**
+     * Normalizes an ISO 8601 string so it can be parsed by SimpleDateFormat.
+     * Strips the colon from the offset, converts Z to +0000, and truncates
+     * microsecond fractional seconds to milliseconds.
+     */
+    public static String normalizeIso8601(String raw) {
+        if (raw == null || raw.isEmpty()) return raw;
+        String normalized = raw;
+        try {
+            if (normalized.length() > 6) {
+                String tail = normalized.substring(normalized.length() - 6);
+                if (tail.matches("[+-]\\d{2}:\\d{2}")) {
+                    normalized = normalized.substring(0, normalized.length() - 6)
+                            + tail.replace(":", "");
+                }
+            }
+            if (normalized.endsWith("Z")) {
+                normalized = normalized.substring(0, normalized.length() - 1) + "+0000";
+            }
+            // Supabase returns microseconds (6 digits after dot). SimpleDateFormat
+            // only handles milliseconds (3 digits). Truncate to 3 digits.
+            normalized = normalized.replaceAll("(\\.\\d{3})\\d+", "$1");
+        } catch (Exception ignored) {}
+        return normalized;
+    }
+
+    private DateUtils() {}
+}


### PR DESCRIPTION
The same regex-based timezone offset normalization logic (strip colon from +07:00, convert Z to +0000, truncate microsecond fractional seconds) was copy-pasted in three places. Extracted into a single `DateUtils` utility so all callers share the same code and edge case fixes apply once.